### PR TITLE
Remove unused storage_account_name var

### DIFF
--- a/modules/consul-cluster/vars.tf
+++ b/modules/consul-cluster/vars.tf
@@ -11,10 +11,6 @@ variable "resource_group_name" {
   description = "The name of the resource group that the resources for consul will run in"
 }
 
-variable "storage_account_name" {
-  description = "The name of the storage account that will be used for images"
-}
-
 variable "subnet_id" {
   description = "The id of the subnet to deploy the cluster into"
 }


### PR DESCRIPTION
Minor change, the `storage_account_name` isn't used but still marked as a required variable 