### PR TITLE
Mark scale set IP configurations primary

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -110,6 +110,7 @@ resource "azurerm_virtual_machine_scale_set" "consul" {
 
     ip_configuration {
       name = "ConsulIPConfiguration"
+      primary = true
       subnet_id = "${var.subnet_id}"
     }
   }
@@ -172,6 +173,7 @@ resource "azurerm_virtual_machine_scale_set" "consul_with_load_balancer" {
 
     ip_configuration {
       name = "ConsulIPConfiguration"
+      primary = true
       subnet_id = "${var.subnet_id}"
       load_balancer_backend_address_pool_ids = [
         "${azurerm_lb_backend_address_pool.consul_bepool.id}"]


### PR DESCRIPTION
I just tried this module in Terraform 0.11.10, and `plan` gave me the following error:

```
Error: module.consul_clients.azurerm_virtual_machine_scale_set.consul_with_load_balancer: "network_profile.0.ip_configuration.0.primary": required field is not set
```

This sounds like the same issue as e.g. https://github.com/Azure/terraform-azurerm-computegroup/issues/19, and adding `primary = true` to the two scale sets in the file let the `plan` succeeds.