### PR TITLE
Fix shell provisioner error and echo behavior

### DIFF
--- a/examples/consul-image/consul.json
+++ b/examples/consul-image/consul.json
@@ -34,7 +34,7 @@
     },
     {
       "type": "shell",
-      "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'",
+      "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh -xe '{{ .Path }}'",
       "inline": [
         "echo \"deb https://packages.microsoft.com/repos/azure-cli/ wheezy main\" | sudo tee /etc/apt/sources.list.d/azure-cli.list",
         "apt-key adv --keyserver packages.microsoft.com --recv-keys 417A0893",
@@ -45,7 +45,6 @@
         "/tmp/terraform-azurerm-consul/modules/install-dnsmasq/install-dnsmasq",
         "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"
       ],
-      "inline_shebang": "/bin/sh -x",
       "pause_before": "30s"
     }
   ]


### PR DESCRIPTION
There were two problems with the shell provisioner:

1. It kept running even if any particular step in the inline script failed
2. It didn't output the commands it ran even though this was desired by setting the `-x` flag in the shebang.

The reason for the first was a missing `-e` flag for the shell, and the reason for the second was that while `-x` _was_ getting set, it was set only in the shebang, but the shebang was being ignored because `execute_command` was explicitly running a shell to execute the provisioner script.

This change fixes both problems by giving the `-x` and `-e` flags directly as part of the `sh` command line args in `execute_command`.