### PR TITLE
Updating Link for Inline Architecture Image

### DIFF
--- a/modules/consul-cluster/README.md
+++ b/modules/consul-cluster/README.md
@@ -122,7 +122,7 @@ Finally, you can try opening up the Consul UI in your browser at the URL `http:/
 
 This module creates the following architecture:
 
-![Consul architecture](https://github.com/hashicorp/terraform-azurerm-vault/tree/master/_docs/architecture.png)
+![Consul architecture](https://github.com/hashicorp/terraform-azurerm-consul/tree/master/_docs/architecture.png)
 
 ## How do you roll out updates?
 


### PR DESCRIPTION
Link was pointing at the vault repo - easy fix!